### PR TITLE
Features/fields translations

### DIFF
--- a/lib/api_utils.rb
+++ b/lib/api_utils.rb
@@ -12,7 +12,7 @@ module ApiUtils
 
   def self.string_to_symbol(s)
     s.gsub!(/[()%]*/, '')
-    s.gsub(' ', '_').downcase.to_sym
+    s.gsub(/[\s\/]/, '_').downcase.to_sym
   end
 
   def self.symbol_to_string(sym)

--- a/lib/zoho_api.rb
+++ b/lib/zoho_api.rb
@@ -37,7 +37,7 @@ module ZohoApi
       x = REXML::Document.new
       element = x.add_element module_name
       row = element.add_element 'row', { 'no' => '1' }
-      fields_values_hash.each_pair { |k, v| add_field(row, ApiUtils.symbol_to_string(k), v) }
+      fields_values_hash.each_pair { |k, v| add_field(row, k, v, module_name) }
       r = self.class.post(create_url(module_name, 'insertRecords'),
                           :query => { :newFormat => 1, :authtoken => @auth_token,
                                       :scope => 'crmapi', :xmlData => x, :wfTrigger => 'true' },
@@ -149,8 +149,8 @@ module ZohoApi
       x = REXML::Document.new
       leads = x.add_element related_module_fields[:related_module]
       row = leads.add_element 'row', { 'no' => '1' }
-      related_module_fields[:xml_data].each_pair { |k, v| add_field(row, ApiUtils.symbol_to_string(k), v) }
-  
+      related_module_fields[:xml_data].each_pair { |k, v| add_field(row, k, v, parent_module) }
+
       r = self.class.post(create_url("#{parent_module}", 'updateRelatedRecords'),
                           :query => { :newFormat => 1,
                                       :id => parent_record_id,
@@ -166,7 +166,7 @@ module ZohoApi
       x = REXML::Document.new
       contacts = x.add_element module_name
       row = contacts.add_element 'row', { 'no' => '1' }
-      fields_values_hash.each_pair { |k, v| add_field(row, ApiUtils.symbol_to_string(k), v) }
+      fields_values_hash.each_pair { |k, v| add_field(row, k, v, module_name) }
       r = self.class.post(create_url(module_name, 'updateRecords'),
                           :query => { :newFormat => 1, :authtoken => @auth_token,
                                       :scope => 'crmapi', :id => id,

--- a/lib/zoho_api_field_utils.rb
+++ b/lib/zoho_api_field_utils.rb
@@ -91,6 +91,8 @@ module ZohoApiFieldUtils
     field = ApiUtils.string_to_symbol(f.to_s)
     @@module_fields[mod_name] << field if method_name?(field)
     @@module_fields[(mod_name.to_s + '_original_name').to_sym] << field
+    @@module_translation_fields[mod_name] ||= {}
+    @@module_translation_fields[mod_name][field.to_s] = f.to_s
   end
 
   def to_hash(xml_results, module_name)

--- a/lib/zoho_api_field_utils.rb
+++ b/lib/zoho_api_field_utils.rb
@@ -1,23 +1,28 @@
 module ZohoApiFieldUtils
 
   @@module_fields = {}
+  @@module_translation_fields = {}
   @@users = []
 
-  def add_field(row, field, value)
+  def add_field(row, field, value, module_name)
     r = (REXML::Element.new 'FL')
-    adjust_tag_case(field)
-    r.attributes['val'] = adjust_tag_case(field)
+    r.attributes['val'] = adjust_tag_case(field.to_s, module_name)
     r.add_text("#{value}")
     row.elements << r
     row
   end
 
-  def adjust_tag_case(tag)
+  def adjust_tag_case(tag, module_name)
     return tag if tag == 'id'
     return tag.upcase if tag.downcase.rindex('id')
     u_tags = %w[SEMODULE]
     return tag.upcase if u_tags.index(tag.upcase)
-    tag
+
+    if @@module_translation_fields[module_name].blank?
+      tag
+    else
+      @@module_translation_fields[module_name][tag] || tag
+    end
   end
 
   def clean_field_name?(field_name)

--- a/lib/zoho_api_field_utils.rb
+++ b/lib/zoho_api_field_utils.rb
@@ -71,6 +71,9 @@ module ZohoApiFieldUtils
     v = n.text == 'null' ? nil : n.text
     r = record.merge({ k => v })
     r = r.merge({ :id => v }) if primary_key?(module_name, k)
+
+    @@module_translation_fields[module_name] ||= {}
+    @@module_translation_fields[module_name][k.to_s] = field_name.to_s
     r
   end
 


### PR DESCRIPTION
Changes needed to translate fields from Zoho to Ruby and remember the proper translations, as explained in #29

This way, I can have an utm_campaing attribute in my Zoho and Ruby will remember that the original attribute is not called Utm Campaign but utm_campaign.

I have tested it with our application (not in production yet) But I couldn't run any spec because I don't have a usable Zoho API Key (the only one I have is populated with real data and I can't run specs over them). Is there any procedure to run specs without a real API Key?