### PR TITLE
Add lastModifiedTime as option for .all and .some

### DIFF
--- a/lib/crud_methods.rb
+++ b/lib/crud_methods.rb
@@ -11,11 +11,11 @@ module CrudMethods
       new(r[0])
     end
 
-    def all #TODO Refactor into low level API
+    def all(last_modified_time = nil) #TODO Refactor into low level API
       max_records = 200
       result = []
       begin
-        batch = RubyZoho.configuration.api.some(self.module_name, result.count + 1, max_records)
+        batch = RubyZoho.configuration.api.some(self.module_name, result.count + 1, max_records, :id, :asc, last_modified_time)
         result.concat(batch) unless batch.nil?
       end until batch.nil? || (batch.length < max_records)
       result.collect { |r| new(r) }

--- a/lib/zoho_api.rb
+++ b/lib/zoho_api.rb
@@ -134,10 +134,11 @@ module ZohoApi
       check_for_errors(r)
     end
 
-    def some(module_name, index = 1, number_of_records = nil, sort_column = :id, sort_order = :asc)
+    def some(module_name, index = 1, number_of_records = nil, sort_column = :id, sort_order = :asc, last_modified_time = nil)
       r = self.class.get(create_url(module_name, 'getRecords'),
                          :query => {:newFormat => 2, :authtoken => @auth_token, :scope => 'crmapi',
                                     :sortColumnString => sort_column, :sortOrderString => sort_order,
+                                    :lastModifiedTime => last_modified_time,
                                     :fromIndex => index, :toIndex => index + (number_of_records || NUMBER_OF_RECORDS_TO_GET) - 1})
       return nil unless r.response.code == '200'
       check_for_errors(r)


### PR DESCRIPTION
I have a need to be able to pull records from zoho that have been changed recently.

```ruby
d = Time.now - 86400
changed_since_yesterday = RubyZoho::Crm::Contact.all(d)
```
The way I chose to address this is inserting an optional parameter ```last_modified_time``` for the .all call and the .some call that takes a date.  .all passes a date on to .some.  .some uses last_modfied_time in the args hash.

I'd rather use a named parameter, but it's not discernable if you are still support 1.8? version of ruby.

There are no tests as I could not come up with anything that wasn't just testing the api itself and the data it returns. I'm happy to implement any suggestions for a testing methodology.