### PR TITLE
Populating no of employees

### DIFF
--- a/lib/api_utils.rb
+++ b/lib/api_utils.rb
@@ -2,15 +2,16 @@ require 'rexml/document'
 
 module ApiUtils
 
+  EXCEPTIONS = {
+      'no_of_employees': 'No of Employees',
+  }
+
   def self.camelize_with_space(str)
-    new_str = str.split('_').map do |w|
-      if w == 'of'
-        w
-      else
-        w.capitalize
-      end
+    if exception = EXCEPTIONS[str.to_sym]
+      exception
+    else
+      str.split('_').map { |w| w.capitalize }.join(' ')
     end
-    new_str.join(' ')
   end
 
   def self.string_to_method_name(s)

--- a/lib/api_utils.rb
+++ b/lib/api_utils.rb
@@ -3,7 +3,7 @@ require 'rexml/document'
 module ApiUtils
 
   EXCEPTIONS = {
-      'no_of_employees': 'No of Employees',
+      no_of_employees: 'No of Employees',
   }
 
   def self.camelize_with_space(str)

--- a/lib/api_utils.rb
+++ b/lib/api_utils.rb
@@ -3,7 +3,14 @@ require 'rexml/document'
 module ApiUtils
 
   def self.camelize_with_space(str)
-    str.split('_').map {|w| w.capitalize}.join(' ')
+    new_str = str.split('_').map do |w|
+      if w == 'of'
+        w
+      else
+        w.capitalize
+      end
+    end
+    new_str.join(' ')
   end
 
   def self.string_to_method_name(s)

--- a/spec/api_utils_spec.rb
+++ b/spec/api_utils_spec.rb
@@ -7,6 +7,8 @@ describe ApiUtils do
 
   it 'should camelize a method name' do
     ApiUtils.camelize_with_space('method_name').should eq('Method Name')
+    ApiUtils.camelize_with_space('no_of_employees').should eq('No of Employees')
+    ApiUtils.camelize_with_space('no_of_employees').should_not eq('No Of Employees')
   end
 
   it 'should convert a string to a method name' do

--- a/spec/ruby_zoho_spec.rb
+++ b/spec/ruby_zoho_spec.rb
@@ -300,7 +300,7 @@ describe RubyZoho::Crm do
           :first_name => 'Raj',
           :last_name => 'Portra',
           :email => 'raj@portra.com',
-			    :no_of_employees => 12345
+          :no_of_employees => 12345
 					)
       l.save
       r = RubyZoho::Crm::Lead.find_by_email('raj@portra.com')

--- a/spec/ruby_zoho_spec.rb
+++ b/spec/ruby_zoho_spec.rb
@@ -299,11 +299,14 @@ describe RubyZoho::Crm do
       l = RubyZoho::Crm::Lead.new(
           :first_name => 'Raj',
           :last_name => 'Portra',
-          :email => 'raj@portra.com')
+          :email => 'raj@portra.com',
+			    :no_of_employees => 12345
+					)
       l.save
       r = RubyZoho::Crm::Lead.find_by_email('raj@portra.com')
       r.should_not eq(nil)
       r.first.email.should eq(l.email)
+      r.first.no_of_employees.should eq(l.no_of_employees.to_s)
       r.each { |c| RubyZoho::Crm::Lead.delete(c.id) }
     end
   end


### PR DESCRIPTION
Patch for issue#61
Modified str.split('_').map {|w| w.capitalize}.join(' '), which was capitalizing 'of' of `no_of_employees`. The correct field name was No of Employees (Shouldn't capitalize 'of').