### PR TITLE
Fix multiple custom module support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -281,6 +281,7 @@ Thanks to a growing and wonderful community!
 @swithik
 @tjsousa
 @wcgiles
+@benknowles
 
 Drop me a line if I've left anybody out and my advance apologies.
 

--- a/lib/crm.rb
+++ b/lib/crm.rb
@@ -63,7 +63,7 @@ class RubyZoho::Crm
 
   def self.setup_classes
     RubyZoho.configuration.crm_modules.each do |module_name|
-      klass_name = module_name.chop
+      klass_name = module_name.start_with?("CustomModule") ? module_name : module_name.chop
       c = Class.new(self) do
         include RubyZoho
         include ActiveModel


### PR DESCRIPTION
Zoho internally uses API names such as CustomModule1, CustomModule2, etc.

Previously if you enabled multiple modules it was chopping off the number and making it so you could only access one RubyZoho::Crm::CustomModule class