### PR TITLE
fix end point url

### DIFF
--- a/lib/zoho_api.rb
+++ b/lib/zoho_api.rb
@@ -97,7 +97,7 @@ module ZohoApi
     end
 
     def create_url(module_name, api_call)
-      "https://crm.zoho.com/crm/private/xml/#{module_name}/#{api_call}"
+      "https://crm.zoho.eu/crm/private/xml/#{module_name}/#{api_call}"
     end
 
     def delete_record(module_name, record_id)


### PR DESCRIPTION
fix <?xml version="1.0" encoding="UTF-8" ?>
<response uri="/crm/private/xml/Accounts/getRecords"><error><code>4834</code><message>Invalid Ticket Id</message></error></response>
by using end point from https://www.zoho.eu/crm/help/api/using-api-url.html